### PR TITLE
Configure tutorial to be script deployable

### DIFF
--- a/.cloudbuild/berglas_setup.sh
+++ b/.cloudbuild/berglas_setup.sh
@@ -14,12 +14,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-export DATABASE_URL=berglas://${PROJECT_ID}-secrets/database_url?destination=/secrets/database_url
-export SECRET_KEY=berglas://${PROJECT_ID}-secrets/secret_key?destination=/secrets/secret_key
-export MEDIA_BUCKET=berglas://${PROJECT_ID}-secrets/media_bucket?destination=/secrets/media_bucket
+export DATABASE_URL=berglas://${BERGLAS_BUCKET}/database_url?destination=/secrets/database_url
+export SECRET_KEY=berglas://${BERGLAS_BUCKET}/secret_key?destination=/secrets/secret_key
+export MEDIA_BUCKET=berglas://${BERGLAS_BUCKET}/media_bucket?destination=/secrets/media_bucket
 
-export SUPERUSER=berglas://${PROJECT_ID}-secrets/superuser?destination=/secrets/superuser
-export SUPERPASS=berglas://${PROJECT_ID}-secrets/superpass?destination=/secrets/superpass
+export SUPERUSER=berglas://${BERGLAS_BUCKET}/superuser?destination=/secrets/superuser
+export SUPERPASS=berglas://${BERGLAS_BUCKET}/superpass?destination=/secrets/superpass
 
 berglas exec --local -- /bin/sh
 
@@ -32,7 +32,6 @@ echo "GS_BUCKET_NAME=$(cat /secrets/media_bucket)" >> $ENVFILE
 
 DBFILE=/secrets/database
 echo "$(cat /secrets/database_url | cut -d'/' -f6)" >> $DBFILE
-
 
 echo "DEBUGGING: cat $ENVFILE"
 for i in $(cat $ENVFILE); do echo $i | cut -d"=" -f1; done

--- a/.cloudbuild/build-migrate-deploy.yaml
+++ b/.cloudbuild/build-migrate-deploy.yaml
@@ -29,6 +29,7 @@ steps:
       args: [".cloudbuild/berglas_setup.sh"]
       env:
         - 'PROJECT_ID=$PROJECT_ID'
+        - 'BERGLAS_BUCKET=${_BERGLAS_BUCKET}'
       volumes:
       - name: secrets
         path: /secrets
@@ -37,7 +38,7 @@ steps:
       name: "gcr.io/google-appengine/exec-wrapper"
       args: ["-i", "gcr.io/$PROJECT_ID/${_IMAGE}",
          "-e", "ENV_PATH=/secrets/.env",
-         "-s", "$PROJECT_ID:us-central1:${_DATABASE_INSTANCE}",
+         "-s", "${_DATABASE_INSTANCE}",
          "--", "sh", ".cloudbuild/django_migrate.sh"]
       volumes:
       - name: secrets
@@ -50,5 +51,6 @@ steps:
 
 # substitutions:
 #   _IMAGE: (the image name)
-#   _DATABASE_INSTANCE: (the database instance)
+#   _DATABASE_INSTANCE: (the database instance name (project:region:instance))
 #   _SERVICE: (the cloud run service)
+#   _BERGLAS_BUCKET: (the bucket in which stores secrets)

--- a/.cloudbuild/django_migrate.sh
+++ b/.cloudbuild/django_migrate.sh
@@ -17,11 +17,11 @@
 #!/bin/sh
 set -e
 
-echo "🦄 loaddata"
-python manage.py loaddata sampledata
-
 echo "🎸 migrate"
 python manage.py migrate
+
+echo "🦄 loaddata"
+python manage.py loaddata sampledata
 
 echo "🎸 collect static"
 python manage.py collectstatic --noinput

--- a/.gcloudignore
+++ b/.gcloudignore
@@ -17,5 +17,6 @@ media/
 
 docs/
 docker-compose.yml
+.util
 
 .DS_Store

--- a/.util/README.md
+++ b/.util/README.md
@@ -1,0 +1,39 @@
+This directory serves to store some utility helpers, that are outside of the deployment of unicodex, but help with the demo as a whole. 
+
+
+### Scriptable Deployment
+
+*This is a stopgap until such a time as terraform [supports](https://dev.to/glasnt/on-the-subject-of-learning-terraform-h4d#beta-providers-again) all the required configurations.*
+
+Using the `shell` markers in `docs/`, it's possible to extract all the code to a single file to at least somewhat automate the setup.
+
+To generate: 
+
+```
+python parse_docs.py /path/to/docs/ 
+```
+
+To deploy: 
+
+ * If your project doesn't already exist: 
+  * Create and enable billing. 
+ * Replace `YourProjectID` with your product
+ * If your database exists already: 
+   * Replace `YourInstanceID` with your existing database instance ID
+   * Replace `PGPASSWORD` with `$(cat /path/to/afilewithyour/PGPASS)`
+
+ * If your database doesn't exist yet: 
+   * Replace `YourInstanceId` with what you want your instance to be called. 
+  
+Your django superuser password will be available in `$PASSWORD`
+
+
+
+The setup assumes a 1:1:1 setup. To optionally deploy multiple instances of unicodex in the same project, additionally: 
+
+ * `s/unicodex/$SLUG/` where `$SLUG` could be, for example `unicodex-stage`
+ * Replace `BERGLAS_BUCKET` with `${PROJECT_ID}-${SLUG}-secrets`
+ * Replace `MEDIA_BUCKET` with `${PROJECT_ID}-${SLUG}-media`
+ * Replace `USERNAME` with `${SLUG}-django`
+
+

--- a/.util/README.md
+++ b/.util/README.md
@@ -1,4 +1,6 @@
-This directory serves to store some utility helpers, that are outside of the deployment of unicodex, but help with the demo as a whole. 
+This directory serves to store some utility helpers, that are outside of the deployment of unicodex, but help with the demo as a whole.
+
+This is assumed to be advanced operator documentation.  
 
 
 ### Scriptable Deployment
@@ -10,24 +12,21 @@ Using the `shell` markers in `docs/`, it's possible to extract all the code to a
 To generate: 
 
 ```
-python parse_docs.py /path/to/docs/ 
+python .util/parse_docs.py docs/ > deploy.sh
 ```
 
 To deploy: 
 
  * If your project doesn't already exist: 
-  * Create and enable billing. 
- * Replace `YourProjectID` with your product
+   * Create and enable billing. 
+ * Replace `YourProjectID` with your project ID
+ * Replace `us-central1` with your preferred region
+   * noting it must support both Cloud Run and Cloud SQL
+ * If your database doesn't exist yet: 
+   * Replace `YourInstanceId` with what you want your instance to be called. 
  * If your database exists already: 
    * Replace `YourInstanceID` with your existing database instance ID
    * Replace `PGPASSWORD` with `$(cat /path/to/afilewithyour/PGPASS)`
-
- * If your database doesn't exist yet: 
-   * Replace `YourInstanceId` with what you want your instance to be called. 
-  
-Your django superuser password will be available in `$PASSWORD`
-
-
 
 The setup assumes a 1:1:1 setup. To optionally deploy multiple instances of unicodex in the same project, additionally: 
 
@@ -37,3 +36,12 @@ The setup assumes a 1:1:1 setup. To optionally deploy multiple instances of unic
  * Replace `USERNAME` with `${SLUG}-django`
 
 
+Then run: 
+
+```
+bash -ex deploy.sh
+```
+  
+Your passwords will be echoed in the output. 
+
+The entire process will take ~10-15 minutes, less if you aren't creating a new database instance. 

--- a/.util/parse_docs.py
+++ b/.util/parse_docs.py
@@ -1,0 +1,50 @@
+# Copyright 2019 Google LLC
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#      http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+
+# parse_docs.py /path/to/docs
+# takes the living tutorial documentation and extracts any stanza marked shell
+
+import re
+import sys
+from pathlib import Path
+
+
+def extract(f, filter=None):
+    code_blocks = []
+    while True:
+        line = f.readline()
+        if not line:
+            # EOF
+            break
+
+        out = re.match("[^`]*```(.*)$", line)
+        if out:
+            if filter and filter.strip() != out.group(1).strip():
+                continue
+            code_block = [f.readline()]
+            while re.search("```", code_block[-1]) is None:
+                code_block.append(f.readline())
+            code_blocks.append("".join(code_block[:-1]))
+    return code_blocks
+
+
+targets = sorted(Path(sys.argv[1]).glob("*.md"))
+
+for x in targets:
+    print(f"# {x.name}")
+    with open(x) as f:
+        data = extract(f, "shell")
+
+    print("\n".join(data))

--- a/README.md
+++ b/README.md
@@ -2,15 +2,16 @@
 
 Let's build a demo application, using a whole bunch o' Google Cloud components. Let's make it just like [emojipedia](https://emojipedia.org/), but let's call it... 
 
-✨ unicodex ✨
+✨ [unicodex](https://unicodex.gl.asnt.app/) ✨
 
 Unicodex uses: 
 
- * [Django 2.2](https://docs.djangoproject.com/en/2.2/) as the web framework,
- * [Google Cloud Run](https://cloud.google.com/run/) as the hosting platform,
- * [Google Cloud SQL](https://cloud.google.com/sql/) as the managed database, via [django-environ](https://django-environ.readthedocs.io/en/latest/),
- * [Google Cloud Storage](https://cloud.google.com/storage/) as the media storage platform, via [django-storages](https://django-storages.readthedocs.io/en/latest/), and
- * [Google Cloud Build](https://cloud.google.com/cloud-build/) for migration and deployment.
+ * [Django 2.2](https://docs.djangoproject.com/en/2.2/) as the web framework
+ * [Google Cloud Run](https://cloud.google.com/run/) as the hosting platform
+ * [Google Cloud SQL](https://cloud.google.com/sql/) as the managed database, via [django-environ](https://django-environ.readthedocs.io/en/latest/)
+ * [Google Cloud Storage](https://cloud.google.com/storage/) as the media storage platform, via [django-storages](https://django-storages.readthedocs.io/en/latest/)
+ * [Google Cloud Build](https://cloud.google.com/cloud-build/) for build and deployment automation
+ * [Google KMS](https://cloud.google.com/kms/) for secret storage, via [berglas](https://github.com/GoogleCloudPlatform/berglas)
 
 *This repo serves as a proof of concept of showing how you can piece all the above technolgies together into a working project.*
 
@@ -42,13 +43,11 @@ Unicodex runs as a Cloud Run service. Using the Python package `django-storages`
 
 In this way, Unicodex runs 1:1:1 -- one Cloud Run Service, one Cloud SQL Database, one Google Storage bucket. It also assumes that there is *only* one service/database/bucket. 
 
-This implementation is live at https://unicodex.gl.asnt.app/
+This implementation is live at [https://unicodex.gl.asnt.app/](https://unicodex.gl.asnt.app/)
 
 ### Other service designs
 
-While the documentation details how to setup a 1:1:1 configuration, with automation steps this could be configured to have a more complex design. For example: one project with one database instance hosting multiple databases, each of those linking to a separate service. This could work for a QA environment, where each developer gets their own "unicodex in a box". In combination with a *seperate* project that serves as the production version, Cloud Build triggers could be setup to: deploy to staging on master merge, and deploy to production on a tagged release.
-
-This configuration is left as an exercise for the reader. 
+With a few find/replace of some critical values, this setup can be converted to have multiple versions of the service each having their own database in a shared instance. More information for this can be found in the [.util](.util/README.md) directory. 
 
 ### TODO
 

--- a/docs/10-setup-gcp.md
+++ b/docs/10-setup-gcp.md
@@ -3,11 +3,11 @@
 
 *The steps listed below are common to doing anything on Google Cloud. If you run into any issues, you can find many step-by-step tutorials on the topic.*
 
-In order to deploy on Google Cloud, you need to sign up. 
+In order to deploy on Google Cloud, you need to sign up (if you haven't already).
 
-Go to [cloud.google.com](https://cloud.google.com/) and click "Get started". 
+To sign up: to [cloud.google.com](https://cloud.google.com/) and click "Get started". 
 
-Once you have signed up, create a new Project.
+Once you have signed up, you need to create a new project.
 
 Notes: 
 
@@ -19,13 +19,21 @@ You will also need to setup this project against a Billing Account.
 
 ---
 
+### 🤔 Think about how long you want to keep this demo
+
+If you happen to already have a Google Cloud Platform account, create a new project for this tutorial demo. 
+
+That way, [cleanup](90-cleanup.md) will be much easier. 
+
+---
+
 We're also going to be using the command line utility for Google Cloud, `gcloud`, wherever possible. 
 
 Go to the [`gcloud` install website](https://cloud.google.com/sdk/docs/#install_the_latest_cloud_tools_version_cloudsdk_current_version) and follow the instructions your operating system. 
 
 To test your `gcloud` works and is up to date: 
 
-```
+```shell,exclude
 gcloud --version
 ```
 
@@ -33,33 +41,33 @@ If you see a "Updates area available" prompt, follow those installation instruct
 
 Next, we need to set our default project. 
 
-```
-export PROJECT_ID=YourProjectId
+```shell
+export PROJECT_ID=YourProjectID
 ```
 
 Setting this as an environment variable will mean when you copy and paste code from this documentation, it will Just Work(tm). Note that this variable will only be set for your current terminal. Run it again if you open a new terminal window. 
 
 To tell `gcloud` about this project, we configure it: 
 
-```
+```shell
 gcloud config set project $PROJECT_ID
 ```
 
 You can check this setting by running: 
 
-```
+```shell,exclude
 gcloud config list
 ```
 
 When we get to the Cloud Run sections, we'll be using the managed Cloud Run platform. To prevent us from having to define that each time (`--platform managed`), we can set the default now: 
 
-```
+```shell
 gcloud config set run/platform managed
 ```
 
 Finally, we will be using a number of Google Cloud services in this tutorial. We can save time by enabling them ahead of time: 
 
-```
+```shell
 gcloud services enable \
     run.googleapis.com \
     compute.googleapis.com \

--- a/docs/20-setup-sql.md
+++ b/docs/20-setup-sql.md
@@ -4,10 +4,21 @@
 
 To store our application data, we'll need to setup a [Cloud SQL](https://console.cloud.google.com/sql/instances) instance, and a specific database with a database user.
 
+---
+
+**This section is one of the more complex parts of this tutorial.** But it's worth going to the effort.
+
+---
+
+It's a *really very good idea* to setup our database in a way that's going to be secure. You *could* run just the basic `gcloud sql` commands here to create an instance and user, but using these commands gives the user [too many permissions](https://cloud.google.com/sql/docs/postgres/users#default-users).
+
+This is why we're taking the time to set things up explicitly. 
+
+---
 
 ### Database Instance
 
-The database instance creation process has many configuration options, but a lot of good defaults, so we're going to follow the [Create a Cloud SQL instance](https://cloud.google.com/sql/docs/postgres/quickstart#create-instance) section of the "Quickstart for Cloud SQL for PostgreSQL" tutorial (rather than running a CLI command.)
+The database instance creation process has many configuration options, as detailed by the [Create a Cloud SQL instance](https://cloud.google.com/sql/docs/postgres/quickstart#create-instance) section of the "Quickstart for Cloud SQL for PostgreSQL" tutorial.
 
 Important notes: 
 
@@ -17,41 +28,40 @@ Important notes:
 
 We can confirm we've correctly setup this database for our project by checking for it in `gcloud`: 
 
-```
+```shell,exclude
 gcloud sql instances list
 ```
 
 Make note of the "NAME", which we will call `INSTANCE_NAME`, to avoid confusion later. We will also use the "LOCATION" later as our `REGION`.
 
+```shell
+export INSTANCE_NAME=YourInstanceName
+export REGION=us-central1 # probably
 ```
-export INSTANCE_NAME=YourinstanceName
-export REGION=us-central1 # probably. 
-```
+
 Note, the region we need may be listed as, for example, "us-central1-a", but we don't require the zone ("-a"). 
 
 ### Our Database 
 
 Our database **instance** can hold many **databases**. For our purposes, we're going to setup a `unicodex` database: 
 
-```
+```shell,exclude
 gcloud sql databases create unicodex --instance=$INSTANCE_NAME
 ```
 
 And then, the user for this database. 
 
+
 Since by default [users created using Cloud SQL have the privileges associated with the `cloudsqlsuperuser` role](https://cloud.google.com/sql/docs/postgres/create-manage-users#creating), and we don't want our django user to have such permissions, we'll have to move to the Cloud Shell for the next part. 
 
----
+Choose your own adventure!
 
-**A note on Cloud Shell**
-
-To help with the ease of setting up our databases, we'll be moving away form our local terminal and using the [Cloud Shell](https://cloud.google.com/shell/docs/quickstart) for part of this tutorial. Cloud Shell is an environment to help us work with managing resources hosted on Google Cloud. 
-
-We *could* run the entire tutorial locally, that would require setting up  the [Cloud SQL Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy), and other configurations. Since we don't need to be here for long, we'll use the Cloud Shell. It also serves as a way to introduce you to the Cloud Shell!
-
-To help, we've prefixed all the Cloud Shell commands in this section with "☁️" to remind you this is for Cloud Shell.
+* Option A: [Use Cloud Shell](#cloud-shell) to interact with the database in the browser
+* Option B: [Setup `cloud_sql_proxy`](#cloud-sql-proxy) and interact with the database on the command line. 
 
 ---
+
+#### Cloud Shell
 
 Go to the [Cloud SQL Console](https://console.cloud.google.com/sql/instances) and select the instance you just created. 
 
@@ -59,41 +69,118 @@ Click on 'Connect using Cloud Shell', and you'll be provisioned a Cloud Shell ma
 
 It should also pre-populate with the command you need: 
 
-```
+```shell,exclude
 ☁️ gcloud sql connect $INSTANCE_NAME --user=postgres --quiet
 ```
 
 You'll be asked for your `MASTER_PASSWORD` that we set earlier. 
 
-We will then be within the **postgres** terminal. This is yet another terminal. We won't be too long. 
+We will then be within the **postgres** terminal. This is yet another terminal. We won't be here too long. 
 
-We can then create our django user: 
-
-```
-CREATE USER django WITH PASSWORD 'secret_password';
-GRANT ALL PRIVILEGES ON ALL TABLES IN SCHEMA public TO django;
-```
-In this case, we are using the `USERNAME` "django" and the `PASSWORD` "secret_password". Of course, you will **use a much more secure password**, won't you? 😊
-
-We can now exit the postgres terminal, and leave the Cloud Shell. 
+But now, it's time to jump to [Creating our database user](#creating-our-database-user) and joining our friends from the Cloud SQL Proxy branch. 
 
 ---
+
+#### Cloud SQL Proxy
+
+If you chose to, we can stay in the console and configure our database user directly. This is going to require the use of [Cloud SQL Proxy](https://cloud.google.com/sql/docs/postgres/sql-proxy). This proxy allows us to establish a temporary authenticated tunnel into our database to perform management commands. 
+
+You'll need to [install](https://cloud.google.com/sql/docs/postgres/sql-proxy#install) the proxy for your system to get started. 
+
+📌 I suggest making sure your proxy is placed somewhere in your `$PATH` so you can invoke it using `cloud_sql_proxy` from anywhere in your terminal. And also, if you install it outside of your current working project, you won't accidentally commit it to your git repo. 
+
+Once you have the proxy installed, we need to setup a tunnel to our database. In a new terminal:
+
+```shell,exclude
+cloud_sql_proxy -instances=$PROJECT_ID:$REGION:$DATABASE_INSTANCE=tcp:5432
+```
+
+
+📌 If you get an error about `bind: address already in use`, just use `5433` or similar. And remember to use this new port in the next command ✨
+
+Then, we can connect to our database: 
+
+```shell,exclude
+psql -U postgres --port 5432 --host localhost
+```
+
+Continue straight into creating your database user!
+
+---
+
+### Creating our database user
+
+The commands we need to execute are creating our user, and giving it access to only our specific database. The form of the command is:
+
+```sql,exclude
+CREATE USER username WITH PASSWORD password; 
+GRANT ALL PRIVILEGES ON DATABASE database TO username;"
+```
+
+Some notes: 
+
+* environment variables won't explicitly work here; they are being used as placeholders.
+* Our django user needs `CREATE` and `ALTER` permissions to perform database migrations. It only needs these permissions on the database we created, not any other database in our instance. 
+
+----
+
+📝 You could execute all the steps in this section up to now non-interactively. You should have an understanding of what these commands are executing before starting. 
+
+```shell
+export INSTANCE_NAME=postgres-django
+export DATABASE_NAME=unicodex
+
+export PGPASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 64 | head -n 1)
+
+gcloud sql instances describe $INSTANCE_NAME --project=$PROJECT_ID &> /dev/null
+
+# only create the instance if it doesn't already exist. 
+if [ $? -ne 0 ]; then
+  gcloud sql instances create $DATABASE_INSTANCE \
+  	 --database-version=POSTGRES_11 \
+  	 --tier=db-f1-micro  \
+	 --region=$REGION \
+	 --project=$PROJECT_ID \ 
+	 --root-password=$PGPASSWORD
+fi
+	 
+export DATABASE_INSTANCE=$PROJECT_ID:$REGION:$INSTANCE_NAME
+
+export USERNAME=django
+export PASSWORD=$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 30 | head -n 1)
+
+gcloud sql databases create $DATABASE_NAME --instance=$INSTANCE_NAME
+
+cloud_sql_proxy -instances=$DATABASE_INSTANCE=tcp:5435 &
+
+psql -U postgres --port 5435 --host localhost -c "CREATE USER \"$USERNAME\" WITH PASSWORD '${PASSWORD}'; GRANT ALL PRIVILEGES ON DATABASE \"$DATABASE_NAME\" TO \"$USERNAME\";"
+```
+
+
+---
+
+### Configuring our Database URL
 
 We now have all the elements we need to create our `DATABASE_URL`. This is a format defined in a lot of systems, including [`django-environ`](https://django-environ.readthedocs.io/en/latest/). 
 
 Back in our **local terminal** (hello old friend!), we will need the `USERNAME` and `PASSWORD` for the `DATABASE_NAME` on the `INSTANCE_NAME` we created, in whatever `REGION` to form the `DATABASE_URL`:
 
-```shell
+```shell,exclude
+# use the values from your previous commands
 export USERNAME=django
 export PASSWORD=secret_password
 export DATABASE_NAME=unicodex
+```
 
+Then, we can create our `DATABASE_URL`:
+
+```shell
 export DATABASE_URL=postgres://$USERNAME:${PASSWORD}@//cloudsql/$PROJECT_ID:$REGION:$INSTANCE_NAME/$DATABASE_NAME
 ```
 
 For convenience, later we will also need a smaller version of this string, which just our absolute Cloud SQL Instance identifer: 
 
-```shell
+```shell,exclude
 export DATABASE_INSTANCE=$PROJECT_ID:$REGION:$INSTANCE_NAME
 ```
 

--- a/docs/30-setup-bucket.md
+++ b/docs/30-setup-bucket.md
@@ -7,7 +7,8 @@ Compared to the complexity of the [last section](20-setup-sql.md) section, this 
 We need to create a new bucket to store our media assets (django admin access, design images, etc). This won't be the last bucket we'll create, so a suggested name is `${PROJECT_ID}-media`.
 
 ```shell
-gsutil mb gs://${PROJECT_ID}-media
+export MEDIA_BUCKET=${PROJECT_ID}-media
+gsutil mb gs://${MEDIA_BUCKET}
 ```
 
 ---

--- a/docs/50-first-deployment.md
+++ b/docs/50-first-deployment.md
@@ -24,7 +24,7 @@ gcloud builds submit --tag gcr.io/$PROJECT_ID/unicodex .
 
 Then, we can (finally!) create our Cloud Run service using this image. We'll also tell it all about the database we setup earlier, and all those secrets: 
 
-```
+```shell
 gcloud beta run deploy unicodex \
     --allow-unauthenticated \
     --region us-central1 \
@@ -44,7 +44,7 @@ Sadly, we have a few more steps. Even though we have deployed our service, **Dja
 
 We can either copy the URL from the output we got from the last step, or we can get it from `gcloud`
 
-```
+```shell,exclude
 gcloud beta run services list
 ```
 
@@ -60,7 +60,7 @@ echo $SERVICE_URL
 
 Then, we can redeploy our service, updating *just* this new environment variable: 
 
-```
+```shell
 gcloud beta run services update unicodex \
 	--update-env-vars CURRENT_HOST=$SERVICE_URL
 ```
@@ -86,7 +86,7 @@ To start with, we need to give Cloud Build permission to access our database, an
 
 This code is similar to the `add-iam-policy-binding` code we used to [setup berglas](40-setup-secrets.md): 
 
-```
+```shell
 export PROJECT_NUMBER=$(gcloud projects describe ${PROJECT_ID} --format 'value(projectNumber)')
 export SA_CB_EMAIL=${PROJECT_NUMBER}@cloudbuild.gserviceaccount.com
 
@@ -104,7 +104,7 @@ You can check the current roles by:
 
 From here, we can then run our `gcloud builds submit` command again, but with new parameters: 
 
-```
+```shell
 gcloud builds submit --config .cloudbuild/build-migrate-deploy.yaml \
     --substitutions="_IMAGE=unicodex,_DATABASE_INSTANCE=${DATABASE_INSTANCE},_SERVICE=unicodex"
 ```
@@ -152,6 +152,11 @@ You can also log in with the `superuser`/`superpass`, and run the admin action a
 ---
 
 🤔 But what if all this didn't work? Check the [Debugging Steps](zz_debugging.md).
+
+
+---
+
+If this is as far as you want to take this project, think about [cleaning up](90-cleanup.md) your resources.
 
 ---
 

--- a/docs/60-ongoing-deployments.md
+++ b/docs/60-ongoing-deployments.md
@@ -43,7 +43,7 @@ From here, we're going to enter the following details:
 * **Cloud Build configuration file location**: `.cloudbuild/build-migrate-deploy.yaml`
 * **Substitution variables**:
   * `_IMAGE`: unicodex
-  * `_DATABASE_INSTANCE`: (your instance name)
+  * `_DATABASE_INSTANCE`: yourproject:yourregion:yourinstance
   * `_SERVICE`: unicodex
 
  

--- a/docs/90-cleanup.md
+++ b/docs/90-cleanup.md
@@ -1,0 +1,12 @@
+# Clean up
+
+If you no longer want to keep your application running, you need to clean it up. 
+
+If you chose to create a new Google Cloud Platform project just for this app, then you can cleanup by deleting the entire project. 
+
+[Here is a detailed run down on how to clean up your project](https://cloud.google.com/python/getting-started/delete-tutorial-resources#deleting-the-project)
+
+#### ⚠️ Please cleanup after yourself ⚠️
+
+Some of the resources created in this documentation have an ongoing cost. If you no longer want to run this application, it's a really good idea to destroy the resources so you are not charged. 
+

--- a/docs/zz_debugging.md
+++ b/docs/zz_debugging.md
@@ -25,19 +25,14 @@ gcloud beta run services update unicodex --update-env-vars DEBUG=False
 
 Is your `DATABASE_URL` correct? Test it with `cloud_sql_proxy`!
 
-Install the [`cloud_sql_proxy` client](https://cloud.google.com/sql/docs/postgres/sql-proxy#install) for your platform. For example, on macOS: 
-
-```
-curl -o cloud_sql_proxy https://dl.google.com/cloudsql/cloud_sql_proxy.darwin.amd64
-chmod +x cloud_sql_proxy
-```
+Install the [`cloud_sql_proxy` client](https://cloud.google.com/sql/docs/postgres/sql-proxy#install) for your platform.  More instructions are in the [database](20-setup-sql.md) section. 
 
 Then, we're going to test our `DATABASE_URL`. Well, some of it. 
 
 In a new terminal:
 
 ```
-./cloud_sql_proxy -instances=$PROJECT_ID:$REGION:$DATABASE_INSTANCE=tcp:5433
+./cloud_sql_proxy -instances=$PROJECT_ID:$REGION:$INSTANCE_NAME=tcp:5433
 ```
 
 You should see "Ready for new connections".
@@ -49,7 +44,7 @@ So, we need to remove the `//cloudsql/.../DATABASE` from our `DATABASE_URL`, and
 So what was once: 
 
 ```
-export TEST_DATABASE_URL=postgres://django:SECRET@//cloudsql/$PROJECT_ID:$REGION:$DATABASE_INSTANCE/$DATABASE_NAME
+export DATABASE_URL=postgres://django:SECRET@//cloudsql/$PROJECT_ID:$REGION:$INSTANCE_NAME/$DATABASE_NAME
 ```
 
 now becomes


### PR DESCRIPTION
By tagging codeblocks and running a grep through the `docs/` folder for that tagged code, we can generate a scriptable version of the entire multipage tutorial. 

More information in `.utils/README.md`