### PR TITLE
Terraform update - Automate Cloud Run Service

### DIFF
--- a/.gcloudignore
+++ b/.gcloudignore
@@ -1,5 +1,6 @@
 #!include:.gitignore
 
+terraform/
 
 .git
 

--- a/terraform/database/outputs.tf
+++ b/terraform/database/outputs.tf
@@ -7,3 +7,8 @@ output "database_instance" {
   description = "The database project-region-instance triple"
   value       = local.database_instance_fqdn
 }
+
+output "short_instance_name" {
+  description = "The short-form instance-only name"
+  value       = google_sql_database_instance.postgres.name
+}

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -52,3 +52,35 @@ module "permissions" {
   region       = var.region
   database_url = module.database.database_url
 }
+
+# Create a Cloud Run service
+module "service" {
+  source = "./service"
+
+  project      = module.services.project_id
+  service      = var.service
+  region       = var.region
+  database_instance = module.database.database_instance
+  service_account_email = module.permissions.service_account_email
+}
+
+# Output the results to the user
+output "result" { 
+    value = <<EOF
+    ✨ 
+    
+    The ${var.service} is now running at ${module.service.service_url}
+
+    You need to perform the initial migrations: 
+
+    cd ..
+    gcloud builds submit --config .cloudbuild/build-migrate-deploy.yaml --substitutions="_REGION=${var.region},_INSTANCE_NAME=${module.database.short_instance_name},_SERVICE=${var.service}"
+
+    You can then log into the service using the superuser name and password: 
+
+    gcloud secrets versions access latest --secret SUPERUSER
+    gcloud secrets versions access latest --secret SUPERPASS
+
+    ✨
+    EOF
+} 

--- a/terraform/permissions/outputs.tf
+++ b/terraform/permissions/outputs.tf
@@ -1,4 +1,5 @@
-output "media_bucket" {
-  description = "The mediabucket in which to store assets"
-  value       = google_storage_bucket.media_bucket.name
+output "service_account_email" {
+  description = "The identifying email address for the Cloud Run service account"
+  value       = google_service_account.cloudrun.email
 }
+

--- a/terraform/service/main.tf
+++ b/terraform/service/main.tf
@@ -1,0 +1,51 @@
+###################################################################################
+
+# Creates a Cloud Run Service
+
+###################################################################################
+
+resource google_cloud_run_service unicodex {
+  name     = var.service
+  location = var.region
+  autogenerate_revision_name = true
+
+  template {
+    spec {
+      containers {
+        image = "gcr.io/${var.project}/${var.service}"
+        env {
+          name = "CURRENT_HOST"
+          value = "*"
+        }
+        env { 
+          name = "DEBUG"
+          value = "True"
+        }
+      }
+      service_account_name = var.service_account_email
+    }    
+    metadata {
+      annotations = {
+        "run.googleapis.com/cloudsql-instances" = var.database_instance
+        "run.googleapis.com/client-name"        = "terraform"
+      }
+    }
+  }
+}
+
+data "google_iam_policy" "noauth" {
+  binding {
+    role = "roles/run.invoker"
+    members = [
+      "allUsers",
+    ]
+  }
+}
+
+resource "google_cloud_run_service_iam_policy" "noauth" {
+  location    = google_cloud_run_service.unicodex.location
+  project     = google_cloud_run_service.unicodex.project
+  service     = google_cloud_run_service.unicodex.name
+
+  policy_data = data.google_iam_policy.noauth.policy_data
+}

--- a/terraform/service/outputs.tf
+++ b/terraform/service/outputs.tf
@@ -1,0 +1,4 @@
+output "service_url" {
+  description = "The URL of the Cloud Run service"
+  value       = google_cloud_run_service.unicodex.status[0].url
+}

--- a/terraform/service/variables.tf
+++ b/terraform/service/variables.tf
@@ -1,0 +1,24 @@
+variable "project" {
+  type        = string
+  description = "The Google Cloud Platform project name"
+}
+
+variable "service" {
+  description = "Name of the service"
+  type        = string
+}
+
+variable "region" {
+  default = "us-central1"
+  type    = string
+}
+
+variable "database_instance" {
+  description = "Name of the postgres instance (PROJECT_ID:REGION:INSTANCE_NAME))"
+  type        = string
+}
+
+variable "service_account_email" { 
+  description = "The identifying email address for the Cloud Run service account"
+  type = string
+}


### PR DESCRIPTION
Still requires manual Cloud Build invocations for:

 * base image creation
 * initial build, migrate, deploy (for initial database migration).

This could be configured as local-exec at a later date.

Update docs to suit.

Notes:

 * Because eventual consistency, CURRENT_HOST is overridden to "*".
 * invocation commands are exported to the user, and should be removed
if automated.