### PR TITLE
Make base django settings a .env file stored in SecretManager

### DIFF
--- a/.env
+++ b/.env
@@ -1,2 +1,0 @@
-#
-REGION=us-central1

--- a/manage.py
+++ b/manage.py
@@ -21,7 +21,7 @@ import sys
 
 
 def main():
-    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+    os.environ.setdefault("DJANGO_SETTINGS_MODULE", "unicodex.settings")
     try:
         from django.core.management import execute_from_command_line
     except ImportError as exc:

--- a/terraform/modules/backing/env.tpl
+++ b/terraform/modules/backing/env.tpl
@@ -1,0 +1,3 @@
+DATABASE_URL="${database_url}"
+GS_BUCKET_NAME="${gs_bucket_name}"
+SECRET_KEY="${secret_key}"

--- a/terraform/modules/backing/secrets.tf
+++ b/terraform/modules/backing/secrets.tf
@@ -1,34 +1,24 @@
-module secret_database_url {
-  source  = "../secret"
-  project = var.project
-
-  name        = "DATABASE_URL"
-  secret_data = var.database_url
-  accessors   = [local.cloudbuild_sa, local.cloudrun_sa]
-}
-
-module secret_gs_media_bucket {
-  source  = "../secret"
-  project = var.project
-
-  name        = "GS_BUCKET_NAME"
-  secret_data = google_storage_bucket.media_bucket.name
-  accessors   = [local.cloudbuild_sa, local.cloudrun_sa]
-}
-
 resource random_password secret_key {
   length  = 50
   special = false
 }
 
-module secret_secret_key {
+module secret_django_settings {
   source  = "../secret"
   project = var.project
 
-  name        = "SECRET_KEY"
-  secret_data = random_password.secret_key.result
+  name        = "django_settings"
+  secret_data = templatefile("${path.module}/env.tpl", 
+    {
+        database_url = var.database_url
+        gs_bucket_name = google_storage_bucket.media_bucket.name
+        secret_key = random_password.secret_key.result
+    }) 
   accessors   = [local.cloudbuild_sa, local.cloudrun_sa]
 }
+
+
+
 
 module secret_superuser {
   source  = "../secret"

--- a/unicodex/wsgi.py
+++ b/unicodex/wsgi.py
@@ -27,6 +27,6 @@ import os
 
 from django.core.wsgi import get_wsgi_application
 
-os.environ.setdefault("DJANGO_SETTINGS_MODULE", "settings")
+os.environ.setdefault("DJANGO_SETTINGS_MODULE", "unicodex.settings")
 
 application = get_wsgi_application()


### PR DESCRIPTION
To reduce the complexity of having to setup 5 secrets, this commit
changes the base django settings to be a file stored in secret manager,
pulled in the event that there is no local .env file (removing the
template .env file).

Shell changes made to suit.
Terraform changes made to suit, using a templatefile.

Also combines moving settings.py to unicodex/settings.py, and associated
file changes