### PR TITLE
Post create, docs improvements

### DIFF
--- a/.gcloud/postcreate.sh
+++ b/.gcloud/postcreate.sh
@@ -18,3 +18,15 @@ gcloud run services update $K_SERVICE --platform managed --region ${GOOGLE_CLOUD
     --service-account ${K_SERVICE}@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com
 
 echo "Post-create configuration complete ✨"
+
+echo ""
+echo ""
+echo "Unicodex is now deployed to ${SERVICE_URL}"
+echo ""
+echo "To login into the Django admin: "
+echo "  * go to ${SERVICE_URL}/admin"
+echo "  * login with the username and password that are stored in Secret Manager"
+echo ""
+echo "gcloud secrets versions access latest --secret SUPERUSER"
+echo "gcloud secrets versions access latest --secret SUPERPASS"
+echo ""

--- a/README.md
+++ b/README.md
@@ -1,43 +1,41 @@
-# Unicodex
+# ✨ [unicodex](https://unicodex.gl.asnt.app/) ✨
 
-Let's build a demo application, using a whole bunch o' Google Cloud components. Let's make it just like [emojipedia](https://emojipedia.org/), but let's call it... 
+Unicodex is a demo database-backed serverless Django application, that uses: 
 
-✨ [unicodex](https://unicodex.gl.asnt.app/) ✨
+ * [Django 3.0](https://docs.djangoproject.com/en/3.0/) as the web framework,
+ * [Google Cloud Run](https://cloud.google.com/run/) as the hosting platform,
+ * [Google Cloud SQL](https://cloud.google.com/sql/) as the managed database (via [django-environ](https://django-environ.readthedocs.io/en/latest/)), 
+ * [Google Cloud Storage](https://cloud.google.com/storage/) as the media storage platform (via [django-storages](https://django-storages.readthedocs.io/en/latest/)),
+ * [Google Cloud Build](https://cloud.google.com/cloud-build/) for build and deployment automation, and
+ * [Google Secret Manager](https://cloud.google.com/secret-manager/) for managing encrypted values.
 
-[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run?branch=button)
+## Deployment
 
-Unicodex uses: 
+This demo can be deployed by multiple different methods. 
 
- * [Django 3.0](https://docs.djangoproject.com/en/3.0/) as the web framework
- * [Google Cloud Run](https://cloud.google.com/run/) as the hosting platform
- * [Google Cloud SQL](https://cloud.google.com/sql/) as the managed database, via [django-environ](https://django-environ.readthedocs.io/en/latest/)
- * [Google Cloud Storage](https://cloud.google.com/storage/) as the media storage platform, via [django-storages](https://django-storages.readthedocs.io/en/latest/)
- * [Google Cloud Build](https://cloud.google.com/cloud-build/) for build and deployment automation
- * [Google Secret Manager](https://cloud.google.com/secret-manager/) for managing encrypted values
+### Automated
 
-*This repo serves as a proof of concept of showing how you can piece all the above technologies together into a working project.*
+[![Run on Google Cloud](https://deploy.cloud.run/button.svg)](https://deploy.cloud.run)
 
-## Steps
+See `app.json` and the `.gcloud/` folder for implementation details.
 
-[Try the application locally](docs/00-test-local.md) *optional*
+### Manual
 
-Manual deployment:
+* [Try the application locally](docs/00-test-local.md) (*optional*)
+* Setup your [Google Cloud environment](docs/10-setup-gcp.md), then provision backing services: 
+  * a [Cloud SQL Instance](docs/20-setup-sql.md),
+  * a [Cloud Storage Bucket](docs/30-setup-bucket.md), and
+  * some [Secrets](docs/40-setup-secrets.md), then
+* Run your [first deployment](docs/50-first-deployment.md)
+* Automate [ongoing deployments](docs/60-ongoing-deployments.md) (*optional*)
 
-1. [Setup Google Cloud Platform environment](docs/10-setup-gcp.md)
-1. [Create a Cloud SQL Instance](docs/20-setup-sql.md)
-1. [Create a Cloud Storage Bucket](docs/30-setup-bucket.md)
-1. [Create some Secrets](docs/40-setup-secrets.md)
-1. [First Deployment](docs/50-first-deployment.md)
-1. [Ongoing Deployments](docs/60-ongoing-deployments.md)
+Don't forget to [cleanup your project resources](docs/90-cleanup.md) when you're done!
 
-Automated deployment: 
+### Terraform 
 
 * [Deploy with Terraform](docs/80-automation.md)
 
-Cleanup: 
-
-* [Cleanup your project resources](docs/90-cleanup.md)
-
+See `terraform/` for configuration details.
 
 ## Application Design
 
@@ -47,7 +45,7 @@ Cleanup:
 
 In Unicodex, these relations are represented by a **codepoint** (Sparkles) having multiple **designs** (images). Each image represents a **version** from a **vendor** (e.g. Google Android 9.0, Twitter Twemoji 1.0, ...). These relations are represented by four models: `Codepoint`, `Design`, `VendorVersion` and `Vendor`, respectively. Designs have a FileField which stores the image. 
 
-In the django admin, an admin action has been setup so that you can select a Codepoint, and run the "Generate designs" actions. This will -- for all configured vendors and vendor versions -- scrape Emojipedia for the information. Alternatively, you can enter this information manually from the django admin. 
+In the Django admin, an admin action has been setup so that you can select a Codepoint, and run the "Generate designs" actions. This will -- for all configured vendors and vendor versions -- scrape Emojipedia for the information. Alternatively, you can enter this information manually from the django admin. 
 
 
 ### Service design - 1:1:1

--- a/README.md
+++ b/README.md
@@ -21,7 +21,9 @@ See `app.json` and the `.gcloud/` folder for implementation details.
 
 ### Terraform 
 
-* [Deploy with Terraform](docs/80-automation.md)
+* Install [Terraform](https://learn.hashicorp.com/terraform/getting-started/install.html) and setup [authentication](docs/80-automation.md#install-terraform-and-setup-authentication)
+* Use Terraform to [provision infrastructure](docs/80-automation.md#provision-infrastructure)
+* Use Cloud Build to perform the initial [database migration](docs/80-automation.md#migrate-database)
 
 See `terraform/` for configuration details.
 

--- a/README.md
+++ b/README.md
@@ -11,7 +11,7 @@ Unicodex is a demo database-backed serverless Django application, that uses:
 
 ## Deployment
 
-This demo can be deployed by multiple different methods. 
+This demo can be deployed by multiple different methods: via the Cloud Run button, through Terraform, or manually via a guided tutorial.  
 
 ### Automated
 
@@ -39,7 +39,6 @@ See `terraform/` for configuration details.
 
 Don't forget to [cleanup your project resources](docs/90-cleanup.md) when you're done!
 
-
 ## Application Design
 
 ### Unicodex itself
@@ -48,12 +47,12 @@ Don't forget to [cleanup your project resources](docs/90-cleanup.md) when you're
 
 In Unicodex, these relations are represented by a **codepoint** (Sparkles) having multiple **designs** (images). Each image represents a **version** from a **vendor** (e.g. Google Android 9.0, Twitter Twemoji 1.0, ...). These relations are represented by four models: `Codepoint`, `Design`, `VendorVersion` and `Vendor`, respectively. Designs have a FileField which stores the image. 
 
-In the Django admin, an admin action has been setup so that you can select a Codepoint, and run the "Generate designs" actions. This will -- for all configured vendors and vendor versions -- scrape Emojipedia for the information. Alternatively, you can enter this information manually from the django admin. 
+In the Django admin, an admin action has been setup so that you can select a Codepoint, and run the "Generate designs" actions. This will -- for all configured vendors and vendor versions -- scrape Emojipedia for the information, including uploading images. Alternatively, you can enter this information manually from the django admin. 
 
 
-### Service design - 1:1:1
+### Service design - one deployment per Google Cloud project
 
-Unicodex runs as a Cloud Run service. Using the Python package `django-storages`, it's been configured to take a `GS_BUCKET_NAME` as a storage place for its media. Using the Python package `django-environ` it takes a complex `DATABASE_URL`, which will point to a Cloud SQL PostgreSQL database. The `settings.py` is also designed to pull specifically named secrets into the environment. These are all designed to live in the same Google Cloud Project. Secrets are given specific names. 
+Unicodex runs as a Cloud Run service. Using the Python package `django-storages`, it's been configured to take a `GS_BUCKET_NAME` as a storage place for its media. Using the Python package `django-environ` it takes a complex `DATABASE_URL`, which will point to a Cloud SQL PostgreSQL database. The `settings.py` is also designed to pull a specific secret into the environment. These are all designed to live in the same Google Cloud Project.
 
 In this way, Unicodex runs 1:1:1 -- one Cloud Run Service, one Cloud SQL Database, one Google Storage bucket. It also assumes that there is *only* one service/database/bucket. 
 

--- a/README.md
+++ b/README.md
@@ -19,6 +19,12 @@ This demo can be deployed by multiple different methods.
 
 See `app.json` and the `.gcloud/` folder for implementation details.
 
+### Terraform 
+
+* [Deploy with Terraform](docs/80-automation.md)
+
+See `terraform/` for configuration details.
+
 ### Manual
 
 * [Try the application locally](docs/00-test-local.md) (*optional*)
@@ -31,11 +37,6 @@ See `app.json` and the `.gcloud/` folder for implementation details.
 
 Don't forget to [cleanup your project resources](docs/90-cleanup.md) when you're done!
 
-### Terraform 
-
-* [Deploy with Terraform](docs/80-automation.md)
-
-See `terraform/` for configuration details.
 
 ## Application Design
 

--- a/docs/80-automation.md
+++ b/docs/80-automation.md
@@ -22,16 +22,16 @@ Once that's setup, you'll need to create a [new service account](https://www.ter
 
 ```shell,exclude
 # Create the service account
-$ gcloud iam service-accounts create terraform \
+gcloud iam service-accounts create terraform \
     --display-name "Terraform Service Account"
 
 # Grant editor permissions (lower than roles/owner)
-$ gcloud projects add-iam-policy-binding ${PROJECT_ID} \
+gcloud projects add-iam-policy-binding ${PROJECT_ID} \
   --member serviceAccount:terraform@${PROJECT_ID}.iam.gserviceaccount.com \
   --role roles/owner
 
 # create and save a local private key
-$ gcloud iam service-accounts keys create ~/terraform-key.json \
+gcloud iam service-accounts keys create ~/terraform-key.json \
   --iam-account terraform@${PROJECT_ID}.iam.gserviceaccount.com 
 
 # store location of private key in environment that terraform can use


### PR DESCRIPTION
Cloud Run button: Post-create now shows username/password access commands (like Terraform deployment does)

Docs updates: refreshed a number of pages, including main landing README.md, headings in Terraform doc for linkability. 