### PR TITLE
Django 3.1, and docs updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 Unicodex is a demo database-backed serverless Django application, that uses: 
 
- * [Django 3.0](https://docs.djangoproject.com/en/3.0/) as the web framework,
+ * [Django 3.1](https://docs.djangoproject.com/en/3.1/) as the web framework,
  * [Google Cloud Run](https://cloud.google.com/run/) as the hosting platform,
  * [Google Cloud SQL](https://cloud.google.com/sql/) as the managed database (via [django-environ](https://django-environ.readthedocs.io/en/latest/)), 
  * [Google Cloud Storage](https://cloud.google.com/storage/) as the media storage platform (via [django-storages](https://django-storages.readthedocs.io/en/latest/)),

--- a/docs/80-automation.md
+++ b/docs/80-automation.md
@@ -21,6 +21,10 @@ To start with, you'll need to [install Terraform](https://learn.hashicorp.com/te
 Once that's setup, you'll need to create a [new service account](https://www.terraform.io/docs/providers/google/getting_started.html#adding-credentials) that has Owner rights to your project, and [export an authentication key](https://cloud.google.com/iam/docs/creating-managing-service-account-keys) to that service account that Terraform can use. 
 
 ```shell,exclude
+# Setup gcloud for your project
+export PROJECT_ID=YourProjectID
+gcloud config set project $PROJECT_ID
+
 # Create the service account
 gcloud iam service-accounts create terraform \
     --display-name "Terraform Service Account"
@@ -88,7 +92,7 @@ cd django-demo-app-unicodex/terraform
 💡 If you chose to run this section in a new project, you will need to re-create the base image: 
 
 ```shell,exclude
-gcloud builds submit --tag gcr.io/MyNewProject/unicodex .
+gcloud builds submit --tag gcr.io/${PROJECT_ID}/unicodex .
 ```
 
 Once you have this configured, you need to initialise Terrafrom:
@@ -112,7 +116,7 @@ You can specify your variables using [command-line flags](https://learn.hashicor
 terraform apply \
   -var 'region=us-central1' \
   -var 'service=unicodex' \
-  -var 'project=MyProject' \
+  -var 'project=${PROJECT_ID}' \
   -var 'instance_name=psql'
 ```
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,11 @@
 Django==3.1
-django-environ
 gunicorn
-pyyaml
-bs4
-requests
+django-environ
 psycopg2-binary
 django-storages[google]
 google-cloud-secret-manager==1.0.0
+
+# required for internal functionality, not deployement related
+requests
+pyyaml
+bs4

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-Django==3.0.7
+Django==3.1
 django-environ
 gunicorn
 pyyaml
@@ -6,4 +6,4 @@ bs4
 requests
 psycopg2-binary
 django-storages[google]
-google-cloud-secret-manager==0.1.1
+google-cloud-secret-manager==1.0.0


### PR DESCRIPTION
This Pull Request updates Django to 3.1, but also: 

 * Updates google-cloud-secret-manager to 1.0.0
 * Reorders requirements to show what is required for the base example, vs what is added for unicodex's internal functionality outside of the deployment to Google Cloud. 
 * Updates terraform documentation to ease process