### PR TITLE
[REVIEW] removed terraform_sa

### DIFF
--- a/terraform/modules/backing/serviceaccount.tf
+++ b/terraform/modules/backing/serviceaccount.tf
@@ -3,13 +3,7 @@ resource google_service_account cloudrun {
   display_name = "${var.service} service account"
 }
 
-data google_service_account terraform {
-  project    = var.project
-  account_id = "terraform"
-}
-
 locals {
   cloudrun_sa   = "serviceAccount:${google_service_account.cloudrun.email}"
   cloudbuild_sa = "serviceAccount:${data.google_project.project.number}@cloudbuild.gserviceaccount.com"
-  terraform_sa  = "serviceAccount:${data.google_service_account.terraform.email}"
 }


### PR DESCRIPTION
remove terraform_sa

* its not used and causes errors as it has no resource definition

```
terraform plan

Error: Invalid template interpolation value

  on modules/backing/serviceaccount.tf line 14, in locals:
  14:   terraform_sa  = "serviceAccount:${data.google_service_account.terraform.email}"
    |----------------
    | data.google_service_account.terraform.email is null

The expression result is null. Cannot include a null value in a string
template.
```

on removal the plan now works

```
Plan: 33 to add, 0 to change, 0 to destroy.

Changes to Outputs:
  + result = (known after apply)

------------------------------------------------------------------------

Note: You didn't specify an "-out" parameter to save this plan, so Terraform
can't guarantee that exactly these actions will be performed if
"terraform apply" is subsequently run.
```