### PR TITLE
Correct access issues

### DIFF
--- a/.gcloud/postcreate.sh
+++ b/.gcloud/postcreate.sh
@@ -17,6 +17,13 @@ gcloud run services update $K_SERVICE --platform managed --region ${GOOGLE_CLOUD
     --add-cloudsql-instances ${GOOGLE_CLOUD_PROJECT}:${GOOGLE_CLOUD_REGION}:psql \
     --service-account ${K_SERVICE}@${GOOGLE_CLOUD_PROJECT}.iam.gserviceaccount.com
 
+echo "→ Removing Compute Service Account secret access"
+export PROJECTNUM=$(gcloud projects describe ${PROJECT_ID} --format 'value(projectNumber)')
+export COMPUTE_SA=${PROJECTNUM}-compute@developer.gserviceaccount.com
+quiet gcloud secrets remove-iam-policy-binding django_settings \
+  --member serviceAccount:$COMPUTE_SA \
+  --role roles/secretmanager.secretAccessor
+
 echo "Post-create configuration complete ✨"
 
 echo ""

--- a/.gcloud/postcreate.sh
+++ b/.gcloud/postcreate.sh
@@ -1,5 +1,7 @@
 #!/bin/bash
 
+source .util/bash_helpers.sh
+
 echo "🚀 Final service configuration changes"
 export SERVICE_URL=$(gcloud run services describe $K_SERVICE  --format "value(status.url)" --platform managed --region ${GOOGLE_CLOUD_REGION})
 

--- a/.gcloud/prebuild.sh
+++ b/.gcloud/prebuild.sh
@@ -33,6 +33,7 @@ stepdone
 export CLOUDRUN_SA=${SERVICE_NAME}@${PROJECT_ID}.iam.gserviceaccount.com
 export PROJECTNUM=$(gcloud projects describe ${PROJECT_ID} --format 'value(projectNumber)')
 export CLOUDBUILD_SA=${PROJECTNUM}@cloudbuild.gserviceaccount.com
+export COMPUTE_SA=${PROJECTNUM}-compute@developer.gserviceaccount.com	
 
 stepdo "Grant IAM permissions to service accounts"
 for role in cloudsql.client run.admin; do
@@ -86,11 +87,10 @@ echo GS_BUCKET_NAME=\"${GS_BUCKET_NAME}\" >> .env
 echo SECRET_KEY=\"$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 50 | head -n 1)\" >> .env
 gcloud secrets create django_settings --replication-policy automatic
 gcloud secrets versions add django_settings --data-file .env
+
+for MEMBER in $CLOUDRUN_SA $CLOUDBUILD_SA $COMPUTE_SA; do
 quiet gcloud secrets add-iam-policy-binding django_settings \
-  --member serviceAccount:$CLOUDRUN_SA \
-  --role roles/secretmanager.secretAccessor
-quiet gcloud secrets add-iam-policy-binding django_settings \
-  --member serviceAccount:$CLOUDBUILD_SA \
+  --member serviceAccount:$MEMBER \
   --role roles/secretmanager.secretAccessor
 rm .env
 stepdone

--- a/.gcloud/prebuild.sh
+++ b/.gcloud/prebuild.sh
@@ -82,17 +82,17 @@ gsutil iam ch \
 stepdone
 
 stepdo "Creating Django settings secret, and allowing service access"
-echo DATABASE_URL=\"${DATABASE_URL}\" > .env
-echo GS_BUCKET_NAME=\"${GS_BUCKET_NAME}\" >> .env
-echo SECRET_KEY=\"$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 50 | head -n 1)\" >> .env
-gcloud secrets create django_settings --replication-policy automatic
-gcloud secrets versions add django_settings --data-file .env
+echo DATABASE_URL=\"${DATABASE_URL}\" > temp_env
+echo GS_BUCKET_NAME=\"${GS_BUCKET_NAME}\" >> temp_env
+echo SECRET_KEY=\"$(cat /dev/urandom | tr -dc 'a-zA-Z0-9' | fold -w 50 | head -n 1)\" >> temp_env
+gcloud secrets create django_settings --data-file temp_env
+rm temp_env
 
 for MEMBER in $CLOUDRUN_SA $CLOUDBUILD_SA $COMPUTE_SA; do
 quiet gcloud secrets add-iam-policy-binding django_settings \
   --member serviceAccount:$MEMBER \
   --role roles/secretmanager.secretAccessor
-rm .env
+
 stepdone
 
 stepdo "Creating Django admin user secrets, and allowing limited access"

--- a/.gcloud/prebuild.sh
+++ b/.gcloud/prebuild.sh
@@ -89,10 +89,11 @@ gcloud secrets create django_settings --data-file temp_env
 rm temp_env
 
 for MEMBER in $CLOUDRUN_SA $CLOUDBUILD_SA $COMPUTE_SA; do
+echo "... Adding $MEMBER..."
 quiet gcloud secrets add-iam-policy-binding django_settings \
   --member serviceAccount:$MEMBER \
   --role roles/secretmanager.secretAccessor
-
+done
 stepdone
 
 stepdo "Creating Django admin user secrets, and allowing limited access"

--- a/terraform/main.tf
+++ b/terraform/main.tf
@@ -31,6 +31,7 @@ resource google_project_iam_binding service_permissions {
     "run.admin", "cloudsql.client"
   ])
 
+  project    = var.project
   role       = "roles/${each.key}"
   members    = [local.cloudbuild_sa, local.unicodex_sa]
   depends_on = [google_service_account.unicodex]


### PR DESCRIPTION
* Compute Engine requires access to the django_settings when deploying with Cloud Run Button, because that's the account that's used by default
* Fixes small terraform config where IAM policy binding requires the project ID
* Small update to not overload the `.env` file, even temporarily, to avoid any hardcoding issues. 