### PR TITLE
Setup multi-domain, update Cloud SQL <> Cloud Build interactions

### DIFF
--- a/.cloudbuild/build-migrate-deploy.yaml
+++ b/.cloudbuild/build-migrate-deploy.yaml
@@ -12,42 +12,64 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 steps:
-    - id: 'build  '
-      name: 'gcr.io/cloud-builders/docker'
-      args: ['build', '-t', 'gcr.io/${PROJECT_ID}/${_SERVICE}', '.']
+  - id: "build  "
+    name: "gcr.io/cloud-builders/docker"
+    args: ["build", "-t", "${_IMAGE_NAME}", "."]
 
-    - id: 'push   '
-      name: 'gcr.io/cloud-builders/docker'
-      args: ['push', 'gcr.io/${PROJECT_ID}/${_SERVICE}']
+  - id: "push   "
+    name: "gcr.io/cloud-builders/docker"
+    args: ["push", "${_IMAGE_NAME}"]
+
+  - id: "layer  "
+    name: "gcr.io/cloud-builders/docker"
+    entrypoint: /bin/bash
+    args:
+      - "-c"
+      - |
+        echo "FROM $_IMAGE_NAME
+        COPY --from=gcr.io/cloudsql-docker/gce-proxy /cloud_sql_proxy /cloudsql/cloud_sql_proxy" > Dockerfile-proxy;
+
+        docker build -f Dockerfile-proxy -t ${_IMAGE_NAME}-proxy .
+
+  - id: "migrate"
+    name: "${_IMAGE_NAME}-proxy"
+    entrypoint: /bin/bash
+    env: 
+      - "PROJECT_ID=$PROJECT_ID"
+      - "USE_CLOUD_SQL_AUTH_PROXY=true"
+    args:
+      - '-c'
+      - |
+        /cloudsql/cloud_sql_proxy -instances=${_INSTANCE_CONNECTION_NAME}=tcp:${_DATABASE_PORT} & sleep 2;
+
+        sh .cloudbuild/django_migrate.sh
       
-    - id: 'migrate'
-      name: 'gcr.io/google-appengine/exec-wrapper'
-      args: ['-i', 'gcr.io/${PROJECT_ID}/${_SERVICE}',
-             '-s', '${PROJECT_ID}:${_REGION}:${_INSTANCE_NAME}',
-             '-e', 'PROJECT_ID=${PROJECT_ID}',
-             '--', 'sh', '.cloudbuild/django_migrate.sh']
-   
-    - id: 'deploy '
-      name: 'gcr.io/google.com/cloudsdktool/cloud-sdk'
-      entrypoint: 'gcloud'
-      args: ["run", "deploy", "${_SERVICE}", 
-            "--platform", "managed", 
-            "--region", "${_REGION}",
-            "--image", "gcr.io/$PROJECT_ID/${_SERVICE}"]
+  - id: "deploy "
+    name: "gcr.io/google.com/cloudsdktool/cloud-sdk"
+    entrypoint: "gcloud"
+    args:
+      [
+        "run",
+        "deploy",
+        "${_SERVICE}",
+        "--platform",
+        "managed",
+        "--region",
+        "${_REGION}",
+        "--image",
+        "${_IMAGE_NAME}",
+      ]
 
-images: 
- - "gcr.io/$PROJECT_ID/${_SERVICE}"
+images:
+  - $_IMAGE_NAME
 
-# Substitutions #
-# Defaults:
+options:
+  dynamic_substitutions: true
 
 substitutions:
-   _SERVICE: unicodex
-   _REGION: us-central1
- 
-# User provided:
-#  _INSTANCE_NAME
-#      - (just the name, PROJECT_ID:REGION:INSTANCE_NAME, since we already have the other values)
-#
-# Automatically provided:
-#  PROJECT_ID: (the project)
+  _SERVICE: unicodex
+  _REGION: us-central1
+  _INSTANCE_NAME: psql
+  _DATABASE_PORT: '5432'
+  _IMAGE_NAME: gcr.io/${PROJECT_ID}/${_SERVICE}
+  _INSTANCE_CONNECTION_NAME: ${PROJECT_ID}:${_REGION}:${_INSTANCE_NAME}

--- a/docs/50-first-deployment.md
+++ b/docs/50-first-deployment.md
@@ -44,9 +44,11 @@ Sadly, we have a few more steps. Even though we have deployed our service, **Dja
 * We need to tell Django where to expect our service to run, and 
 * we need to initialise our database.
 
-#### Service URL, and `ALLOWED_HOSTS` 
+#### Service URL, CSRF, and `ALLOWED_HOSTS` 
 
 Django has a setting called `ALLOWED_HOSTS`, which recommended to be defined for [security purposes](https://docs.djangoproject.com/en/3.0/ref/settings/#allowed-hosts). We want our set our `ALLOWED_HOSTS` to be the service URL of the site we just deployed. 
+
+New in Django 4.0, we will also want to set the [`TRUSTED_CSRF_DOMAIN` value](https://docs.djangoproject.com/en/4.0/ref/csrf/) as well. 
 
 When we deployed our service, it told us the service URL that our site can be accessed from. We can either copy the URL from the output we got from the last step, or we can get it from `gcloud`
 
@@ -70,7 +72,7 @@ gcloud run services update $SERVICE_NAME \
   --update-env-vars "CURRENT_HOST=${SERVICE_URL}"
 ```
 
-In this case, `CURRENT_HOST` is setup in our [settings.py](../settings.py) to be added to the `ALLOWED_HOSTS`, if defined. 
+In this case, `CURRENT_HOST` is setup in our [settings.py](../settings.py) to be parsed into the `ALLOWED_HOSTS` and `TRUSTED_CSRF_DOMAIN` settings. 
 
 **Important**: Django's `ALLOWED_HOSTS` takes a hostname without a scheme (i.e. without the leading 'https'). Our `settings.py` handles this by removing it, if it appears. 
 

--- a/docs/50-first-deployment.md
+++ b/docs/50-first-deployment.md
@@ -48,7 +48,7 @@ Sadly, we have a few more steps. Even though we have deployed our service, **Dja
 
 Django has a setting called `ALLOWED_HOSTS`, which recommended to be defined for [security purposes](https://docs.djangoproject.com/en/3.0/ref/settings/#allowed-hosts). We want our set our `ALLOWED_HOSTS` to be the service URL of the site we just deployed. 
 
-New in Django 4.0, we will also want to set the [`TRUSTED_CSRF_DOMAIN` value](https://docs.djangoproject.com/en/4.0/ref/csrf/) as well. 
+New in Django 4.0, we will also want to set the [`TRUSTED_CSRF_DOMAIN` value](https://docs.djangoproject.com/en/4.0/ref/csrf/) as well. [Read more about how not setting this can break Cloud Run deployments](https://cloud.google.com/blog/topics/developers-practitioners/follow-pink-pony-story-csrf-managed-services-and-unicorns).
 
 When we deployed our service, it told us the service URL that our site can be accessed from. We can either copy the URL from the output we got from the last step, or we can get it from `gcloud`
 

--- a/unicodex/settings.py
+++ b/unicodex/settings.py
@@ -54,10 +54,10 @@ DEBUG = env("DEBUG", default=False)
 
 
 # If defined, add service URL to Django security settings
-CURRENT_HOST = env("CURRENT_HOST", default=None)
+CURRENT_HOST = env.list("CURRENT_HOST", default=None)
 if CURRENT_HOST:
-    ALLOWED_HOSTS = [urlparse(CURRENT_HOST).netloc]
-    CSRF_TRUSTED_ORIGINS = [CURRENT_HOST]
+    ALLOWED_HOSTS = [urlparse(host).netloc for host in CURRENT_HOST]
+    CSRF_TRUSTED_ORIGINS = CURRENT_HOST
 else:
     ALLOWED_HOSTS = ["localhost"]
     CSRF_TRUSTED_ORIGINS = ["http://localhost"]


### PR DESCRIPTION
* The deployments of unicodex have custom domains, so `CURRENT_HOST` needs to be a list. 
* Apply updates based on [the new Cloud Build to Cloud SQL interaction doc](https://cloud.google.com/sql/docs/postgres/connect-build)
* Update docs based on Django 4.0's CSRF changes
